### PR TITLE
fixed Nested List Markdown Formatting issue

### DIFF
--- a/src/sass/partials/layouts/_events.scss
+++ b/src/sass/partials/layouts/_events.scss
@@ -218,6 +218,20 @@
       @media #{$media-small} {
         font-size: 1em;
       }
+      ul{
+        font-size: 1em;
+      }
+      ul ul{
+        margin-top: 10px;
+      }
+      ul li{
+        a {
+          text-decoration: none;
+          color: #02b839;
+          display: inline;
+        }
+      }
+
       li {
         a {
           text-decoration: none;

--- a/src/sass/partials/layouts/_events.scss
+++ b/src/sass/partials/layouts/_events.scss
@@ -221,6 +221,10 @@
       ul{
         font-size: 1em;
       }
+      ul p{
+        font-size: 1em;
+        margin: 0px;
+      }
       ul ul{
         margin-top: 10px;
       }


### PR DESCRIPTION

Fixes #239 
- Fixed the issue where the nested list contents undergo a font-size multiplier of 1.2em multiple times
- Fixed sizing of the pre-nested element (p) and removed its extra margin
- added top margin to nested list for better formatting
- retained link styles for nested list elements
