### PR TITLE
FIX overflow of link to the gaps between the boxes #429

### DIFF
--- a/src/sass/partials/layouts/_team.scss
+++ b/src/sass/partials/layouts/_team.scss
@@ -18,9 +18,9 @@
   .card-link {
     text-decoration: none;
     color: inherit;
+    margin-right: 3.18rem;
   }
   .member-card {
-    width: 80%;
     height: auto;
     margin: 10px 0px;
     border-radius: 2px;


### PR DESCRIPTION
After my fix the gap between two cards is no more clickable. Please review the code changes at your earliest convenience and let me know if any changes are required.

